### PR TITLE
issues 154, 160, 152

### DIFF
--- a/airflow/dags/sentinel2/Sentinel2.py
+++ b/airflow/dags/sentinel2/Sentinel2.py
@@ -80,15 +80,15 @@ metadata_task = Sentinel2MetadataOperator(task_id = 'dhus_metadata_task',
                                           remote_dir = sentinel2_config['granules_upload_dir'],
                                           dag = dag)
 
-# Archive Sentinel-2 RSYNC with .prj and .tfw files Task Operator
-archive_tfwprj_task = RSYNCOperator(task_id="sentinel2_upload_granules_with_tfwprj", 
+# Archive Sentinel-2 RSYNC with .prj and .wld files Task Operator
+archive_wldprj_task = RSYNCOperator(task_id="sentinel2_upload_granules_with_wldprj", 
                              host = "localhost", 
                              remote_usr = "moataz", 
                              ssh_key_file = "/usr/local/airflow/id_rsa", 
                              remote_dir = sentinel2_config['granules_upload_dir'], 
                              xk_pull_dag_id = 'Sentinel2',
                              xk_pull_task_id = 'dhus_metadata_task', 
-                             xk_pull_key = 'downloaded_products_with_tfwprj',
+                             xk_pull_key = 'downloaded_products_with_wldprj',
                              dag=dag)
 
 # Sentinel-2 Product.zip Operator.
@@ -103,4 +103,4 @@ product_zip_task = Sentinel2ProductZipOperator(task_id = 'product_zip_task',
                                                placeholders = placeholders_list,
                                                dag = dag)
 
-search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_tfwprj_task >> product_zip_task
+search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_wldprj_task >> product_zip_task

--- a/airflow/dags/sentinel2/Sentinel2.py
+++ b/airflow/dags/sentinel2/Sentinel2.py
@@ -1,0 +1,106 @@
+import logging, os
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators import DHUSSearchOperator, DHUSDownloadOperator, Sentinel2ThumbnailOperator, Sentinel2MetadataOperator, Sentinel2ProductZipOperator, RSYNCOperator
+from sentinel1.secrets import dhus_credentials
+from sentinel2.config import sentinel2_config
+
+log = logging.getLogger(__name__)
+
+# Settings
+default_args = {
+    ##################################################
+    # General configuration
+    #
+    'start_date': datetime.today() - timedelta(days=1),
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'provide_context': True,
+    'email': ['airflow@evoodas.dlr.de'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'max_threads': 1,
+    # 'queue': 'bash_queue',
+    # 'pool': 'backfill',
+    # 'priority_weight': 10,
+    # 'end_date': datetime(2016, 1, 1),
+    #
+}
+
+# DAG definition
+dag = DAG('Sentinel2', description='DAG for searching, filtering and downloading Sentinel-2 data from DHUS server',
+          default_args = default_args,
+          dagrun_timeout = timedelta(hours=10),
+          schedule_interval = '0 * * * *',
+          catchup = False)
+
+# Sentinel2- Search Task Operator
+search_task = DHUSSearchOperator(task_id = 'dhus_search_task',
+                                 dhus_url = 'https://scihub.copernicus.eu/dhus',
+                                 dhus_user = dhus_credentials['username'],
+                                 dhus_pass = dhus_credentials['password'],
+                                 geojson_bbox = sentinel2_config['geojson_bbox'],
+                                 startdate = sentinel2_config['startdate'],
+                                 enddate = sentinel2_config['enddate'],
+                                 platformname = sentinel2_config['platformname'],
+                                 filename = sentinel2_config['filename'],
+                                 dag = dag)
+
+# Sentinel-2 Download Task Operator
+download_task = DHUSDownloadOperator(task_id = 'dhus_download_task',
+                                     dhus_url = 'https://scihub.copernicus.eu/dhus',
+                                     dhus_user = dhus_credentials['username'],
+                                     dhus_pass = dhus_credentials['password'],
+                                     download_max = sentinel2_config['download_max'],
+                                     download_dir = sentinel2_config['download_dir'],
+                                     dag = dag)
+
+# Archive Sentinel-2 RSYNC Task Operator
+archive_task = RSYNCOperator(task_id="sentinel2_upload_granules", 
+                             host = "localhost", 
+                             remote_usr = "moataz", 
+                             ssh_key_file = "/usr/local/airflow/id_rsa", 
+                             remote_dir = sentinel2_config['granules_upload_dir'], 
+                             xk_pull_dag_id = 'Sentinel2', 
+                             xk_pull_task_id = 'dhus_download_task', 
+                             xk_pull_key = 'downloaded_products_paths',
+                             dag=dag)
+
+
+# Sentinel-2 Create thumbnail Operator
+thumbnail_task = Sentinel2ThumbnailOperator(task_id = 'dhus_thumbnail_task',
+                                            thumb_size_x = '64',
+                                            thumb_size_y = '64',
+                                            dag=dag)
+
+# Sentinel-2 Metadata Operator
+metadata_task = Sentinel2MetadataOperator(task_id = 'dhus_metadata_task',
+                                          bands_res = sentinel2_config['bands_res'],
+                                          remote_dir = sentinel2_config['granules_upload_dir'],
+                                          dag = dag)
+
+# Archive Sentinel-2 RSYNC with .prj and .tfw files Task Operator
+archive_tfwprj_task = RSYNCOperator(task_id="sentinel2_upload_granules_with_tfwprj", 
+                             host = "localhost", 
+                             remote_usr = "moataz", 
+                             ssh_key_file = "/usr/local/airflow/id_rsa", 
+                             remote_dir = sentinel2_config['granules_upload_dir'], 
+                             xk_pull_dag_id = 'Sentinel2',
+                             xk_pull_task_id = 'dhus_metadata_task', 
+                             xk_pull_key = 'downloaded_products_with_tfwprj',
+                             dag=dag)
+
+# Sentinel-2 Product.zip Operator.
+# The following variables are just pointing to placeholders until we implement the real files.
+base_dir = "/usr/local/airflow/metadata-ingestion/templates"
+placeholders_list = [os.path.join(base_dir,"metadata.xml"), os.path.join(base_dir,"owsLinks.json"), os.path.join(base_dir,"product_abstract.html")]
+generated_files_list = ['product/product.json','product/granules.json','product/thumbnail.jpeg']
+
+product_zip_task = Sentinel2ProductZipOperator(task_id = 'product_zip_task',
+                                               target_dir = sentinel2_config["product_zip_target_dir"],
+                                               generated_files = generated_files_list,
+                                               placeholders = placeholders_list,
+                                               dag = dag)
+
+search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_tfwprj_task >> product_zip_task

--- a/airflow/dags/sentinel2/config.py
+++ b/airflow/dags/sentinel2/config.py
@@ -17,14 +17,15 @@ download_base_dir= '/var/data/download/'
 sentinel2_config = {
     'download_max': '1',
     'geojson_bbox': '/var/data/regions/germany.geojson',
-    'startdate': (datetime.today() - timedelta(days=10)).isoformat() + 'Z',
+    'startdate': (datetime.today() - timedelta(days=4)).isoformat() + 'Z',
     'enddate': enddate,
     'platformname': 'Sentinel-2',
     'filename': 'S2A_MSIL1C*',
     'download_dir': os.path.join(download_base_dir, "Sentinel-2"),
-    'granules_upload_dir': "/var/data/download/uploads",
-    'bands_res':{'10':("B02","B03","B04","B08"),'20':("B05","B06","B07","B8A","B11","B12"),'60':("B01","B09","B10")},
     'rsync_hostname': 'geoserver.cloudsdi.geo-solutions.it',
     'rsync_username': 'ec2-user',
     'rsync_ssh_key' : '/usr/local/airflow/id_rsa'
+    'granules_upload_dir': "/var/data/sentinel2/uploads",
+    'product_zip_target_dir':"/var/data/download/Sentinel-2", 
+    'bands_res':{'10':("B02","B03","B04","B08"),'20':("B05","B06","B07","B8A","B11","B12"),'60':("B01","B09","B10")}
 }

--- a/airflow/dags/sentinel2/config.py
+++ b/airflow/dags/sentinel2/config.py
@@ -17,7 +17,7 @@ download_base_dir= '/var/data/download/'
 sentinel2_config = {
     'download_max': '1',
     'geojson_bbox': '/var/data/regions/germany.geojson',
-    'startdate': (datetime.today() - timedelta(days=4)).isoformat() + 'Z',
+    'startdate': (datetime.today() - timedelta(days=10)).isoformat() + 'Z',
     'enddate': enddate,
     'platformname': 'Sentinel-2',
     'filename': 'S2A_MSIL1C*',
@@ -26,6 +26,9 @@ sentinel2_config = {
     'rsync_username': 'ec2-user',
     'rsync_ssh_key' : '/usr/local/airflow/id_rsa'
     'granules_upload_dir': "/var/data/sentinel2/uploads",
+    'bands_res':{'10':("B02","B03","B04","B08"),'20':("B05","B06","B07","B8A","B11","B12"),'60':("B01","B09","B10")},
     'product_zip_target_dir':"/var/data/download/Sentinel-2", 
-    'bands_res':{'10':("B02","B03","B04","B08"),'20':("B05","B06","B07","B8A","B11","B12"),'60':("B01","B09","B10")}
+    'rsync_hostname': 'geoserver.cloudsdi.geo-solutions.it',
+    'rsync_username': 'ec2-user',
+    'rsync_ssh_key' : '/usr/local/airflow/id_rsa'
 }

--- a/airflow/plugins/dhus_plugin.py
+++ b/airflow/plugins/dhus_plugin.py
@@ -90,7 +90,7 @@ class DHUSDownloadOperator(BaseOperator):
             dhus_user,
             dhus_pass,
             download_dir,
-            download_timeout=timedelta(hours=1),
+            download_timeout=timedelta(hours=5),
             download_max=100,
             product_ids=None,
             *args, **kwargs):

--- a/airflow/plugins/evo-odas_plugin.py
+++ b/airflow/plugins/evo-odas_plugin.py
@@ -6,7 +6,7 @@ from airflow.operators import PythonOperator
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.decorators import apply_defaults
 from zipfile import ZipFile
-import config.xcom_keys as xk
+import xcom_keys as xk
 from sentinel1.utils.ssat1_metadata import create_procuct_zip
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This PR includes fixes for 154, 160, 152 issues:
154: The "location" property of the granules in the granules.json file contained in the product.zip is not set correctly. It was pointing to the path of the granule inside the .zip original uploaded file. however, it was supposed to point to the granule which is uploaded from the "granules with tfw and prj files" because Geoserver can't read the granules from within the zipped package.
160: there was a key (sentinel2_config["product_zip_target_dir"]) passed to the Sentinel2ProductZipOperator task and not found in the S2 config file.
152: creating .tfw and .prj files as a solution to create the required georeferentiation information