### PR TITLE
Update DHUS Plugin to sentinelsat 0.12

### DIFF
--- a/airflow/dags/sentinel1/Sentinel1.py
+++ b/airflow/dags/sentinel1/Sentinel1.py
@@ -61,8 +61,7 @@ search_task = DHUSSearchOperator(task_id='dhus_search_task',
                                  geojson_bbox=ew_grdm_1sdv_config['geojson_bbox'],
                                  startdate=ew_grdm_1sdv_config['startdate'],
                                  enddate=ew_grdm_1sdv_config['enddate'],
-                                 platformname=ew_grdm_1sdv_config['platformname'],
-                                 filename=ew_grdm_1sdv_config['filename'],
+                                 keywords = ew_grdm_1sdv_config['search_keywords'],
                                  dag=main_dag)
 
 # DHUS Download Task Operator

--- a/airflow/dags/sentinel1/config.py
+++ b/airflow/dags/sentinel1/config.py
@@ -23,8 +23,10 @@ ew_grdm_1sdh_config = {
     'geojson_bbox': '/var/data/regions/daraa.geojson',
     'startdate': startdate,
     'enddate': enddate,
-    'platformname': platformname,
-    'filename': 'S1?_EW_GRDM_1SDH*',
+    'search_keywords' : {
+        'filename': 'S1?_EW_GRDM_1SDH*',
+        'platformname': platformname,
+    },
     'download_dir': download_dir,
     'granules_upload_dir': '/efs/geoserver_data/coverages/sentinel/sentinel1/grd/EW_GRDM_1SDH'
 }
@@ -34,8 +36,10 @@ ew_grdm_1sdv_config = {
     'geojson_bbox': '/var/data/regions/germany.geojson',
     'startdate': startdate,
     'enddate': enddate,
-    'platformname': platformname,
-    'filename': 'S1?_*_GRD?_1SDV*',
+    'search_keywords' : {
+        'filename': 'S1?_*_GRD?_1SDV*',
+        'platformname': platformname,
+    },
     'download_dir': download_dir,
     'granules_upload_dir': '/efs/geoserver_data/coverages/sentinel/sentinel1/grd/EW_GRDM_1SDV'
 }

--- a/airflow/dags/sentinel2/Sentinel2.py
+++ b/airflow/dags/sentinel2/Sentinel2.py
@@ -43,8 +43,7 @@ search_task = DHUSSearchOperator(task_id = 'dhus_search_task',
                                  geojson_bbox = sentinel2_config['geojson_bbox'],
                                  startdate = sentinel2_config['startdate'],
                                  enddate = sentinel2_config['enddate'],
-                                 platformname = sentinel2_config['platformname'],
-                                 filename = sentinel2_config['filename'],
+                                 keywords = sentinel2_config['search_keywords'],
                                  dag = dag)
 
 # Sentinel-2 Download Task Operator

--- a/airflow/dags/sentinel2/config.py
+++ b/airflow/dags/sentinel2/config.py
@@ -19,8 +19,12 @@ sentinel2_config = {
     'geojson_bbox': '/var/data/regions/germany.geojson',
     'startdate': (datetime.today() - timedelta(days=10)).isoformat() + 'Z',
     'enddate': enddate,
-    'platformname': 'Sentinel-2',
-    'filename': 'S2A_MSIL1C*',
+    'search_keywords' : {
+        'filename': 'S2A_MSIL1C*',
+        'platformname': 'Sentinel-2',
+        'orbitdirection':'Descending',
+        'cloudcoverpercentage':'[0 TO 5]'
+    },
     'download_dir': os.path.join(download_base_dir, "Sentinel-2"),
     'granules_upload_dir': "/var/data/sentinel2/uploads",
     'bands_res': {'10':("B02","B03","B04","B08"),'20':("B05","B06","B07","B8A","B11","B12"),'60':("B01","B09","B10")},


### PR DESCRIPTION
This commit updates the dhus plugin and updates the existing Sentinel 1+2 DAGs and config accordingly.

 - Sentinelsat api call as it has changed in 0.12. Note that this is not backward compatible so after merging you should update to sentinelsat to the latest version.

 - There is a new `search_keywords` dict parameter that replaces the `filename` and `platformname` parameters. This dict can be populated by [well-defined keywords](https://scihub.copernicus.eu/userguide/3FullTextSearch) to refine the search.

 - The Sentinel-1 and -2 DAGs as well as it's configuration have been updated to use the new `search_keywords`.

 - The operators now also `return` the products dict in addition to push them via xcom.

Resolves: #180