### PR TITLE
Feature 17 fixing issue 124 and modify GetCoverage call parameters 

### DIFF
--- a/airflow/dags/sentinel2/Sentinel2.py
+++ b/airflow/dags/sentinel2/Sentinel2.py
@@ -100,9 +100,9 @@ archive_wldprj_task = RSYNCOperator(task_id="sentinel2_upload_granules",
 
 # Sentinel-2 Product.zip Operator.
 # The following variables are just pointing to placeholders until we implement the real files.
-base_dir = "/usr/local/airflow/metadata-ingestion/templates"
-placeholders_list = [os.path.join(base_dir,"metadata.xml"), os.path.join(base_dir,"owsLinks.json"), os.path.join(base_dir,"product_abstract.html")]
-generated_files_list = ['product/product.json','product/granules.json','product/thumbnail.jpeg']
+CWR = os.path.dirname(os.path.realpath(__file__))
+placeholders_list = [os.path.join(CWR,"metadata.xml"), os.path.join(CWR,"product_abstract.html")]
+generated_files_list = ['product/product.json','product/granules.json','product/thumbnail.jpeg', 'product/owsLinks.json']
 
 product_zip_task = Sentinel2ProductZipOperator(task_id = 'product_zip_task',
                                                target_dir = sentinel2_config["product_zip_target_dir"],

--- a/airflow/dags/sentinel2/utils.py
+++ b/airflow/dags/sentinel2/utils.py
@@ -52,11 +52,11 @@ def generate_wms_dict(GS_WORKSPACE, GS_LAYER, granule_coordinates, GS_WMS_WIDTH,
             "offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wms"
         }
 
-def generate_wcs_dict(granule_coordinates, s2_product, coverage_id):
+def generate_wcs_dict(granule_coordinates, GS_WORKSPACE, s2_product, coverage_id):
     long1, long2 = (float(granule_coordinates[0][3][0].split(",")[0]),float(granule_coordinates[0][1][0].split(",")[0]))
     lat1, lat2 = (float(granule_coordinates[0][3][0].split(",")[1]),float(granule_coordinates[0][1][0].split(",")[1]))
     return {"offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wcs",
                           "method": "GET",
                           "code": "GetCoverage",
-                          "type": "application/json",
-                          "href": r"${BASE_URL}"+"/test/wcs?service=WCS&version=2.0.1&coverageId={}&request=GetCoverage&format=jpeg2000&subset=http://www.opengis.net/def/axis/OGC/0/**Long({},{})&subset=http://www.opengis.net/def/axis/OGC/0/Lat({},{})**&scaleaxes=i(0.1),j(0.1)**&CQL_FILTER=eoIdentifier='{}'**".format(coverage_id, str(long1).strip(), str(long2).strip(), str(lat1).strip(), str(lat2).strip(), s2_product.manifest_safe_path.rsplit('.SAFE', 1)[0])}
+                          "type": "image/jpeg",
+                          "href": r"${BASE_URL}"+"/{}/wcs?service=WCS&version=2.0.1&coverageId={}&request=GetCoverage&format=jpeg2000&subset=http://www.opengis.net/def/axis/OGC/0/Long({},{})&subset=http://www.opengis.net/def/axis/OGC/0/Lat({},{})&scaleaxes=i(0.1),j(0.1)&CQL_FILTER=eoIdentifier='{}'".format(GS_WORKSPACE, coverage_id, str(long1).strip(), str(long2).strip(), str(lat1).strip(), str(lat2).strip(), s2_product.manifest_safe_path.rsplit('.SAFE', 1)[0])}


### PR DESCRIPTION
In this PR, the way of saving the metadata files to the product.zip is improved. now it saves the generated and placeholder files outside the S2 product zip file. then it creates the product.zip containing the meta-data files 