### PR TITLE
Refactor S1 DAG and plugins to use new configuration management

### DIFF
--- a/airflow/dags/config/s1_grd_1sdv.py
+++ b/airflow/dags/config/s1_grd_1sdv.py
@@ -5,8 +5,8 @@ import config
 #
 # Collection
 #
-id = "S1_GRD_1SDH"
-filename_filter = "S1?_EW_GRDM_1SDH*"
+id = "S1_GRD_1SDV"
+filename_filter = "S1?_*_GRD?_1SDV*"
 platformname = 'Sentinel-1'
 collection_dir = os.path.join(config.base_dir, platformname, id)
 download_dir = os.path.join(collection_dir,"download")
@@ -17,17 +17,17 @@ repository_dir = os.path.join(collection_dir,"repository")
 #
 # DHUS specific
 #
-dhus_filter_max = 2
+dhus_filter_max = 5
+dhus_download_max = 1
 dhus_search_bbox = os.path.join(config.regions_base_dir,'europe.geojson')
 dhus_search_filename = filename_filter
-dhus_search_startdate = datetime.today() - timedelta(days=4)
+dhus_search_startdate = datetime.today() - timedelta(days=14)
 dhus_search_startdate = dhus_search_startdate.isoformat() + 'Z'
 dhus_search_enddate = datetime.now().isoformat() + 'Z'
-dhus_search_orderby = '-ingestiondate'
+dhus_search_orderby = '+ingestiondate'
 dhus_search_keywords = {
         'filename': filename_filter,
-        'platformname': platformname,
-        'orbitdirection':'Descending',
+        'platformname': platformname
 }
 
 #
@@ -37,15 +37,15 @@ geoserver_workspace = "sentinel"
 geoserver_layer = "SENTINEL1"
 geoserver_coverage = "SENTINEL1"
 geoserver_oseo_collection="SENTINEL1"
-geoserver_oseo_wms_width = 512
-geoserver_oseo_wms_height = 512
-geoserver_oseo_wms_format = "tiff"
+geoserver_oseo_wms_width = 768
+geoserver_oseo_wms_height = 768
+geoserver_oseo_wms_format = "image/png"
 
 #
 # Product
 #
 
 try:
-    from override.s1_grd_1sdh import *
+    from override.s1_grd_1sdv import *
 except:
     pass

--- a/airflow/dags/config/s2_msi_l1c.py
+++ b/airflow/dags/config/s2_msi_l1c.py
@@ -17,7 +17,8 @@ repository_dir = os.path.join(collection_dir,"repository")
 #
 # DHUS specific
 #
-dhus_filter_max = 2
+dhus_filter_max = 5
+dhus_download_max = dhus_filter_max
 dhus_search_bbox = os.path.join(config.regions_base_dir,'europe.geojson')
 dhus_search_filename = filename_filter
 dhus_search_startdate = datetime.today() - timedelta(days=4)

--- a/airflow/dags/config/settings.py
+++ b/airflow/dags/config/settings.py
@@ -14,6 +14,8 @@ repository_base_dir = os.getenv('REPOSITORY_DIR',os.path.join(base_dir, 'reposit
 dhus_url = 'https://scihub.copernicus.eu/dhus'
 dhus_username = ''
 dhus_password = ''
+dhus_filter_max = 2
+dhus_download_max = dhus_filter_max
 
 geoserver_rest_url = 'http://localhost:8080/geoserver/rest'
 geoserver_username = 'admin'

--- a/airflow/dags/sentinel1/S1_GRD_1SDV.py
+++ b/airflow/dags/sentinel1/S1_GRD_1SDV.py
@@ -1,0 +1,133 @@
+import logging, os, inspect
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators import BashOperator, DHUSSearchOperator, DHUSDownloadOperator, ZipInspector, MockDownload, SubDagOperator, PythonOperator, RSYNCOperator
+from airflow.operators import S1MetadataOperator
+from airflow.models import XCOM_RETURN_KEY
+
+from geoserver_plugin import publish_product
+from sentinel1.s1_grd_subdag_factory import gdal_processing_sub_dag
+import config as CFG
+import config.s1_grd_1sdv as S1GRD1SDV
+
+log = logging.getLogger(__name__)
+
+# Settings
+default_args = {
+    ##################################################
+    # General configuration
+    #
+    'start_date': datetime.now() - timedelta(hours=1),
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'provide_context': True,
+    'email': ['airflow@evoodas.dlr.de'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'max_threads': 1,    
+    # 'queue': 'bash_queue',
+    # 'pool': 'backfill',
+    # 'priority_weight': 10,
+    # 'end_date': datetime(2016, 1, 1),
+    #
+}
+
+print("#######################")
+print("ID: {}".format(S1GRD1SDV.id))
+print("DHUS:  {} @ {}, Region: {}".format(CFG.dhus_username, CFG.dhus_url, S1GRD1SDV.dhus_search_bbox) )
+print("GeoServer: {} @ {}".format(CFG.geoserver_username, CFG.geoserver_rest_url) )
+print("RSYNC: {} @ {} using {}".format(CFG.rsync_username, CFG.rsync_hostname, CFG.rsync_ssh_key))
+print("Date: {} / {}".format(S1GRD1SDV.dhus_search_startdate, S1GRD1SDV.dhus_search_enddate))
+print("Search: max={}, order_by={}, keywords={}".format(S1GRD1SDV.dhus_filter_max, S1GRD1SDV.dhus_search_orderby,S1GRD1SDV.dhus_search_keywords))
+print("Paths:\n  collection_dir={}\n  download_dir={}\n  process_dir={}\n  upload_dir={}\n  repository_dir={}".format(S1GRD1SDV.collection_dir, S1GRD1SDV.download_dir, S1GRD1SDV.process_dir, S1GRD1SDV.upload_dir, S1GRD1SDV.repository_dir))
+print("Collection:\n  workspace={}\n  layer={}".format(S1GRD1SDV.geoserver_workspace, S1GRD1SDV.geoserver_layer))
+print("#######################")
+
+# DAG definition
+dag = DAG(S1GRD1SDV.id, 
+          description='DAG for searching, filtering and downloading Sentinel 1 data from DHUS server',
+          schedule_interval='@hourly',
+          default_args=default_args
+)
+
+# DHUS Search Task Operator
+search_task = DHUSSearchOperator(task_id='search_product_task',
+                                 dhus_url=CFG.dhus_url,
+                                 dhus_user=CFG.dhus_username,
+                                 dhus_pass=CFG.dhus_password,
+                                 geojson_bbox=S1GRD1SDV.dhus_search_bbox,
+                                 startdate=S1GRD1SDV.dhus_search_startdate,
+                                 enddate=S1GRD1SDV.dhus_search_enddate,
+                                 filter_max=S1GRD1SDV.dhus_filter_max,
+                                 order_by=S1GRD1SDV.dhus_search_orderby,
+                                 keywords=S1GRD1SDV.dhus_search_keywords,
+                                 dag=dag)
+
+# DHUS Download Task Operator
+download_task = DHUSDownloadOperator(task_id='download_product_task',
+                                     dhus_url=CFG.dhus_url,
+                                     dhus_user=CFG.dhus_username,
+                                     dhus_pass=CFG.dhus_password,
+                                     download_max=S1GRD1SDV.dhus_download_max,
+                                     download_dir=S1GRD1SDV.download_dir,
+                                     get_inputs_from=search_task.task_id,
+                                     download_timeout=timedelta(hours=12),
+                                     dag=dag)
+
+# Zip Inspector and Extractor Task
+zip_task = ZipInspector(task_id='zip_inspector',
+                        extension_to_search='tiff',
+                        get_inputs_from=download_task.task_id,
+                        dag=dag)
+
+# GDAL Processing SubDAG
+sentinel1_gdal_task = SubDagOperator(task_id='sentinel1_gdal',
+                                     subdag = gdal_processing_sub_dag(S1GRD1SDV.id, 
+                                                                      'sentinel1_gdal', 
+                                                                      datetime(2017, 5, 4), 
+                                                                      "0 11 * * *",
+                                                                      working_dir=S1GRD1SDV.process_dir),
+                                     dag=dag)
+
+# Metadata Extraction task
+metadata_task = S1MetadataOperator(task_id="extract_metadata_task",
+                                   product_safe_path=None,
+                                   granules_paths=None,
+                                   granules_upload_dir=S1GRD1SDV.repository_dir,
+                                   working_dir=S1GRD1SDV.process_dir,
+                                   get_inputs_from=download_task.task_id,
+                                   dag=dag)
+
+# Rsync Archive Task for Granules
+upload_task = RSYNCOperator(task_id="upload_granules_task", 
+                            host = CFG.rsync_hostname, 
+                            remote_usr = CFG.rsync_username,
+                            ssh_key_file = CFG.rsync_ssh_key, 
+                            remote_dir = S1GRD1SDV.repository_dir,
+                            xk_pull_dag_id = S1GRD1SDV.id + '.sentinel1_gdal',
+                            xk_pull_task_id = 'gdal_addo_1',
+                            xk_pull_key = 'dstfile',
+                            dag=dag)
+
+# Rsync Archive Task for Products
+archive_task = RSYNCOperator(task_id="archive_product_task", 
+                             host = CFG.rsync_hostname, 
+                             remote_usr = CFG.rsync_username,
+                             ssh_key_file = CFG.rsync_ssh_key, 
+                             remote_dir = S1GRD1SDV.repository_dir,
+                             get_inputs_from=download_task.task_id,
+                             dag=dag)
+
+# Publish product.zip to GeoServer
+publish_task = PythonOperator(task_id="publish_product_task",
+                              python_callable=publish_product,
+                              op_kwargs={
+                                'geoserver_username': CFG.geoserver_username,
+                                'geoserver_password': CFG.geoserver_password,
+                                'geoserver_rest_endpoint': '{}/oseo/collections/{}/products'.format(CFG.geoserver_rest_url, S1GRD1SDV.geoserver_oseo_collection),
+                                'get_inputs_from': metadata_task.task_id,
+                              },
+                              dag = dag)
+
+search_task >> download_task >> zip_task >> sentinel1_gdal_task >> metadata_task >> upload_task >> archive_task >> publish_task

--- a/airflow/dags/sentinel1/Sentinel1.py
+++ b/airflow/dags/sentinel1/Sentinel1.py
@@ -48,7 +48,7 @@ main_dag = DAG(DAG_NAME, description='DAG for searching, filtering and downloadi
           catchup=False)
 
 sentinel1_gdal_task = SubDagOperator(
-    subdag = gdal_processing_sub_dag(DAG_NAME, SUBDAG_NAME, DATE, INTERVAL),
+    subdag = gdal_processing_sub_dag(DAG_NAME, SUBDAG_NAME, DATE, INTERVAL,working_dir="/var/data/working"),
     task_id=SUBDAG_NAME,
     dag=main_dag
 )
@@ -116,6 +116,7 @@ sentinel1_upload_granule_2 = RSYNCOperator(
 metadata_task = S1MetadataOperator(
     task_id="s1_metadata_extraction",
     dag=main_dag,
+    working_dir="/var/data/working",
     product_safe_path=None,
     granules_paths=None,
     granules_upload_dir=ew_grdm_1sdv_config['granules_upload_dir'],

--- a/airflow/dags/sentinel1/s1_grd_subdag_factory.py
+++ b/airflow/dags/sentinel1/s1_grd_subdag_factory.py
@@ -7,13 +7,13 @@ from sentinel1.secrets import geoserver_credentials
 log = logging.getLogger(__name__)
 
 # Dag is returned by a factory method
-def gdal_processing_sub_dag(parent_dag_name, child_dag_name, start_date, schedule_interval):
+def gdal_processing_sub_dag(parent_dag_name, child_dag_name, start_date, schedule_interval, working_dir='/var/data/working'):
 
   TARGET_SRS = 'EPSG:4326'
   TILE_SIZE = 512
-  WORKING_DIR = '/var/data/working'
+  WORKING_DIR = working_dir
   OVERWRITE = True
-
+  
   RESAMPLING_METHOD = 'average'
   MAX_OVERVIEW_LEVEL = 512
 

--- a/airflow/dags/sentinel1/utils/ssat1_metadata.py
+++ b/airflow/dags/sentinel1/utils/ssat1_metadata.py
@@ -256,12 +256,6 @@ def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_uplo
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
 
-    # dump product.json to file
-    path = os.path.join(working_dir, 'product.json')
-    with open(path, 'w') as f:
-        json.dump(search_params, f, indent=4)
-    files.append(path)
-
     # create description.html and dump it to file
     tr = TemplatesResolver()
     try:
@@ -305,6 +299,19 @@ def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_uplo
         json.dump(granules_dict, f, indent=4)
     files.append(path)
 
+    # Use the coordinates from the granules in the product.json as the s1reader seems to
+    # swap the footprint coordinates, see https://github.com/geosolutions-it/evo-odas/issues/192
+    granule_coords=granules_dict.get('features')[0].get('geometry').get('coordinates')
+    #print(">>>>>>>>>>>>>{}".format(granule_coords))
+    search_params['geometry']['coordinates']=granule_coords
+    #print(">>>>>>>>>>>>>{}".format(search_params.get('geometry').get('coordinates')))
+    
+    # dump product.json to file
+    path = os.path.join(working_dir, 'product.json')
+    with open(path, 'w') as f:
+        json.dump(search_params, f, indent=4)
+    files.append(path)
+
     # create owslinks.json and dump it to file
     owslinks_dict = create_owslinks_dict(s1metadata, granules_paths, bbox_str)
     path = os.path.join(working_dir, 'owslinks.json')
@@ -335,3 +342,4 @@ def main(sentinel1_product_zip_path):
 
 if __name__ == "__main__":
     main(sys.argv[1])
+

--- a/airflow/dags/sentinel1/utils/ssat1_metadata.py
+++ b/airflow/dags/sentinel1/utils/ssat1_metadata.py
@@ -8,31 +8,33 @@ from shutil import copyfile
 from zipfile import ZipFile
 from S1Reader import S1GDALReader
 from templates_renderer import TemplatesResolver
+import config as CFG
+import config.s1_grd_1sdv as S1GRD1SDV
 
 # OWS links settings for WMS
-GS_WMS_WORKSPACE="test"
-GS_WMS_LAYER="SENTINEL1_MOSAIC"
+GS_WMS_WORKSPACE=S1GRD1SDV.geoserver_workspace
+GS_WMS_LAYER=S1GRD1SDV.geoserver_layer
 GS_WMS_VERSION="1.3.0"
-GS_WMS_WIDTH="768"
-GS_WMS_HEIGHT="768"
-GS_WMS_FORMAT="image/jpeg"
+GS_WMS_WIDTH=S1GRD1SDV.geoserver_oseo_wms_width
+GS_WMS_HEIGHT=S1GRD1SDV.geoserver_oseo_wms_height
+GS_WMS_FORMAT=S1GRD1SDV.geoserver_oseo_wms_format
 
 # OWS links settings for WFS
-GS_WFS_WORKSPACE="test"
-GS_WFS_LAYER="SENTINEL1"
+GS_WFS_WORKSPACE=S1GRD1SDV.geoserver_workspace
+GS_WFS_LAYER=S1GRD1SDV.geoserver_layer
 GS_WFS_VERSION="2.0.0"
 GS_WFS_FORMAT="application/json"
 
 # OWS links settings for WCS
-GS_WCS_WORKSPACE="test"
-GS_WCS_LAYER="SENTINEL1_MOSAIC"
+GS_WCS_WORKSPACE=S1GRD1SDV.geoserver_workspace
+GS_WCS_LAYER=S1GRD1SDV.geoserver_coverage
 GS_WCS_VERSION="2.0.1"
 GS_WCS_SCALE_I='0.1'
 GS_WCS_SCALE_J='0.1'
 GS_WCS_FORMAT="geotiff"
 
 
-WORKING_DIR='/var/data/working'
+WORKING_DIR=S1GRD1SDV.process_dir
 
 try:
     from osgeo import gdal
@@ -236,8 +238,7 @@ def get_bbox_from_granule(granule_path):
     urx, ury = (lrx, uly)
     return [ [ulx,uly], [llx,lly], [lrx,lry], [urx,ury], [ulx,uly] ]
 
-def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_upload_dir):
-    working_dir = WORKING_DIR
+def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_upload_dir, working_dir=WORKING_DIR):
     s1reader = S1GDALReader(sentinel1_product_zip_path)
     files = []
 
@@ -251,6 +252,9 @@ def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_uplo
     log.info(pprint.pformat(search_params))
     log.info(pprint.pformat(other_metadata))
     log.info(pprint.pformat(product_abstract_metadata))
+
+    if not os.path.exists(working_dir):
+        os.makedirs(working_dir)
 
     # dump product.json to file
     path = os.path.join(working_dir, 'product.json')
@@ -322,7 +326,7 @@ def create_procuct_zip(sentinel1_product_zip_path, granules_paths, granules_uplo
     for file in files:
         os.remove(file)
 
-    return s1metadata
+    return path
 
 def main(sentinel1_product_zip_path):
     log = logging.getLogger(__name__)

--- a/airflow/dags/sentinel2/S2_MSI_L1C.py
+++ b/airflow/dags/sentinel2/S2_MSI_L1C.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.operators import DHUSSearchOperator, DHUSDownloadOperator, Sentinel2ThumbnailOperator, Sentinel2MetadataOperator, Sentinel2ProductZipOperator, RSYNCOperator, BashOperator, PythonOperator
 
-from sentinel2.utils import publish_product
+from geoserver_plugin import publish_product
 import config as CFG
 import config.s2_msi_l1c as S2MSIL1C
 
@@ -74,7 +74,7 @@ download_task = DHUSDownloadOperator(task_id='download_product_task',
                                      dhus_url=CFG.dhus_url,
                                      dhus_user=CFG.dhus_username,
                                      dhus_pass=CFG.dhus_password,
-                                     download_max=S2MSIL1C.dhus_filter_max,
+                                     download_max=S2MSIL1C.dhus_download_max,
                                      download_dir=S2MSIL1C.download_dir,
                                      get_inputs_from=search_task.task_id,
                                      download_timeout=timedelta(hours=8),
@@ -116,7 +116,7 @@ archive_wldprj_task = RSYNCOperator(task_id="archive_wldprj_task",
                                     remote_usr = CFG.rsync_username,
                                     ssh_key_file = CFG.rsync_ssh_key, 
                                     remote_dir = S2MSIL1C.repository_dir,
-                                    get_inputs_from=metadata_task.task_id,                              
+                                    get_inputs_from=metadata_task.task_id,                           
                                     dag=dag)
 
 ## Sentinel-2 Product.zip Operator.

--- a/airflow/dags/sentinel2/Sentinel2.py
+++ b/airflow/dags/sentinel2/Sentinel2.py
@@ -2,7 +2,7 @@ import logging, os
 from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.operators import DHUSSearchOperator, DHUSDownloadOperator, Sentinel2ThumbnailOperator, Sentinel2MetadataOperator, Sentinel2ProductZipOperator, RSYNCOperator, BashOperator, PythonOperator
-from sentinel2.utils import publish_product
+from geoserver_plugin import publish_product
 from sentinel1.secrets import dhus_credentials, geoserver_credentials
 from sentinel2.config import sentinel2_config, geoserver_url, geoserver_collection_name
 

--- a/airflow/dags/sentinel2/utils.py
+++ b/airflow/dags/sentinel2/utils.py
@@ -5,47 +5,6 @@ from airflow.models import XCOM_RETURN_KEY
 
 log = logging.getLogger(__name__)
 
-def publish_product(geoserver_username, geoserver_password, geoserver_rest_endpoint, get_inputs_from, *args, **kwargs):
-    # Pull Zip path from XCom
-    log.info("publish_product task")
-    log.info("""
-        geoserver_username: {}
-        geoserver_password: ******
-        geoserver_rest_endpoint: {}
-        """.format(
-        geoserver_username,
-        geoserver_rest_endpoint
-        )
-    )
-    task_instance = kwargs['ti']
-
-    if get_inputs_from != None:
-        log.info("Getting inputs from: " +get_inputs_from)
-        zip_files = task_instance.xcom_pull(task_ids=get_inputs_from, key=XCOM_RETURN_KEY)
-    else:
-        log.info("Getting inputs from: product_zip_task" )
-        zip_files = task_instance.xcom_pull('product_zip_task', key='product_zip_paths')
-    
-    log.info("zip_file_paths: {}".format(zip_files))
-    if zip_files is not None:
-        for zip_file in zip_files:
-            # POST product.zip
-            d = open(zip_file, 'rb').read()
-            a = requests.auth.HTTPBasicAuth(geoserver_username, geoserver_password)
-            h = {'Content-type': 'application/zip'}
-
-            r = requests.post(geoserver_rest_endpoint,
-                auth=a,
-                data=d,
-                headers=h)
-
-            log.info('response\n{}'.format(pformat(r.text)))
-            if not r.status_code == requests.codes.ok:
-                #r.raise_for_status()
-                log.warn("Couldn't publish {} (HTTP {})".format(zip_file, r.status_code))
-    else:
-        log.warn("No product.zip found.")
-
 def generate_wfs_dict(s2_product, GS_WORKSPACE, GS_LAYER):
     
     return {"offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wfs",

--- a/airflow/plugins/dhus_plugin.py
+++ b/airflow/plugins/dhus_plugin.py
@@ -153,8 +153,17 @@ class DHUSDownloadOperator(BaseOperator):
         product_downloaded = {}
         api = SentinelAPI(self.dhus_user, self.dhus_pass, self.dhus_url)
         for product_id in self.products.keys():
+
+            # If download limit reached, stopp and break out
+            # Else if the file already exists, then try next from search
+            product_filename=os.path.join(self.download_dir,self.products[product_id].get("title")+".zip")
             if len(product_downloaded) >= self.download_max:
+                log.info("Limit exceeded, stopping download..")
                 break;
+            elif os.path.exists(product_filename):
+                log.info("Product already downloaded. Continuing..")
+                continue
+
             log.info('Download Product ID {}'.format(product_id))
             downloaded = api.download(product_id, directory_path=self.download_dir);
             path = downloaded['path']

--- a/airflow/plugins/evo-odas_plugin.py
+++ b/airflow/plugins/evo-odas_plugin.py
@@ -19,43 +19,48 @@ log = logging.getLogger(__name__)
 
 class ZipInspector(BaseOperator):
     @apply_defaults
-    def __init__(self, extension_to_search, *args, **kwargs):
+    def __init__(self, extension_to_search,  get_inputs_from=None, *args, **kwargs):
         self.substring = extension_to_search
+        self.get_inputs_from = get_inputs_from
         log.info('--------------------GDAL_PLUGIN Zip inspector------------')
         super(ZipInspector, self).__init__(*args, **kwargs)
 
     def execute(self, context):
-        log.info('**** Inside execute ****')
-        task_instance = context['task_instance']
-        log.info("ZipInspector Operator params list")
-        log.info('Substring to search: %s', self.substring)
-
-        downloaded = task_instance.xcom_pull(task_ids='dhus_download_task', key='downloaded_products')
-        log.info("Downloaded products: " + pprint.pformat(downloaded))
-        zip_filename = None
-        # TODO: Only handling one at a time
-        for k in downloaded:
-            zip_filename = downloaded[k]['path']
-            break
-        if zip_filename is None:
-            log.error("No Zip file retrived via XCom. Nothing to do")
-            raise TypeError
-
-        log.info('Zip filename: %s', zip_filename)
-        zip = ZipFile(zip_filename)
-        counter = 0;
-        for file in zip.namelist():
-            filename = zip.getinfo(file).filename
-            if self.substring in filename:
-                counter = counter + 1
-                raster_vsizip = "/vsizip/" + zip_filename + "/" + filename
-                log.info(str(counter) + ") '" + raster_vsizip + "'")
-                task_instance.xcom_push(key=xk.IMAGE_ZIP_ABS_PATH_PREFIX_XCOM_KEY + str(counter), value=raster_vsizip)
-        if counter == 0:
-            log.info("No files found in the zip archive...")
-            return True
+        zip_files=list()
+        if self.get_inputs_from != None:
+            zip_files = context['task_instance'].xcom_pull(task_ids=self.get_inputs_from, key=XCOM_RETURN_KEY)
         else:
-            return False
+            #legacy 
+            log.info('**** Inside execute ****')
+            log.info("ZipInspector Operator params list")
+            log.info('Substring to search: %s', self.substring)
+
+            downloaded = context['task_instance'].xcom_pull(task_ids='dhus_download_task', key='downloaded_products')
+            zip_files = downloaded.keys()
+        
+        # stop processing if there are no products
+        if zip_files is None or len(zip_files)==0:
+            log.info("Nothing to process.")
+            return
+
+        return_dict=dict()
+        log.info("Processing {} ZIP files:\n{} ".format(len(zip_files),pprint.pformat(zip_files)))
+        for zip_file in zip_files:
+            log.info("Processing {}..".format(zip_file))
+            counter = 0;
+            vsi_paths=list()
+            zip = ZipFile(zip_file)
+            for file in zip.namelist():
+                filename = zip.getinfo(file).filename
+                if self.substring in filename:
+                    counter = counter + 1
+                    raster_vsizip = "/vsizip/" + zip_file + "/" + filename
+                    vsi_paths.append(raster_vsizip)
+                    log.info(str(counter) + ") '" + raster_vsizip + "'")
+                    context['task_instance'].xcom_push(key=xk.IMAGE_ZIP_ABS_PATH_PREFIX_XCOM_KEY + str(counter), value=raster_vsizip)
+            return_dict[zip_file]=vsi_paths
+
+        return return_dict
 
 class RSYNCOperator(BaseOperator):
 
@@ -127,11 +132,13 @@ class RSYNCOperator(BaseOperator):
 
 class S1MetadataOperator(BaseOperator):
     @apply_defaults
-    def __init__(self, product_safe_path, granules_paths, granules_upload_dir, xk_pull_dag_id=None, xk_pull_task_id=None, xk_pull_key_safe=None, xk_pull_key_granules_paths=None, xk_push_key=None,
+    def __init__(self, product_safe_path, granules_paths, granules_upload_dir, working_dir, get_inputs_from=None, xk_pull_dag_id=None, xk_pull_task_id=None, xk_pull_key_safe=None, xk_pull_key_granules_paths=None, xk_push_key=None,
                  *args, **kwargs):
         self.product_safe_path = product_safe_path
         self.granules_paths = granules_paths
         self.granules_upload_dir = granules_upload_dir
+        self.working_dir = working_dir
+        self.get_inputs_from = get_inputs_from
         self.xk_pull_dag_id = xk_pull_dag_id
         self.xk_pull_task_id = xk_pull_task_id
         self.xk_pull_key_safe = xk_pull_key_safe
@@ -148,6 +155,7 @@ class S1MetadataOperator(BaseOperator):
             product_safe_path: {}
             granules_paths: {}
             granules_upload_dir: {}
+            get_inputs_from: {}
             xk_pull_task_id: {}
             xk_pull_dag_id: {}
             xk_pull_key_safe: {}
@@ -157,6 +165,7 @@ class S1MetadataOperator(BaseOperator):
             self.product_safe_path,
             self.granules_paths,
             self.granules_upload_dir,
+            self.get_inputs_from,
             self.xk_pull_task_id,
             self.xk_pull_dag_id,
             self.xk_pull_key_safe,
@@ -167,23 +176,31 @@ class S1MetadataOperator(BaseOperator):
         # init XCom parameters
         if self.xk_pull_dag_id is None:
             self.xk_pull_dag_id = context['dag'].dag_id
+
         # check input file path passed otherwise look for it in XCom
+        product_safe_path = None
         if self.product_safe_path is not None:
             product_safe_path = self.product_safe_path
+        elif self.get_inputs_from is not None:
+            inputs = context['task_instance'].xcom_pull(task_ids=self.get_inputs_from, key=XCOM_RETURN_KEY) 
+            log.info("Receiving from 'get_input_from':\n{}".format(inputs))
+            if inputs is not None and len(inputs.keys()) > 0:
+                product_safe_path = inputs.keys()[0]
+                self.working_dir = os.path.join(self.working_dir,inputs[product_safe_path].get('title'))
         else:
             if self.xk_pull_key_safe is None:
                 self.xk_pull_key_safe = 'product_safe_path'
             # log.info('XCom Pull: task_ids: {} key: {} dag_id: {}'.format(self.xk_pull_task_id, self.xk_pull_key_safe, self.xk_pull_dag_id))
             downloaded = task_instance.xcom_pull(task_ids='dhus_download_task', key='downloaded_products', dag_id=self.xk_pull_dag_id)
-            zip_filename = None
             for k in downloaded:
-                zip_filename = downloaded[k]['path']
+                product_safe_path = downloaded[k]['path']
                 break
-        if zip_filename is None:
-            log.error("No Zip file retrived via XCom")
-            raise TypeError
-        log.info('product_safe_path: %s', zip_filename)
 
+        if product_safe_path is None:
+            log.error("No Zip file retrived via XCom")
+            return
+
+        log.info('product_safe_path: %s', product_safe_path)
 
         if self.granules_paths is not None:
             granules_paths = self.granules_paths
@@ -213,12 +230,15 @@ class S1MetadataOperator(BaseOperator):
             task_id="s1_metadata_dictionary_creation",
             python_callable=create_procuct_zip,
             op_kwargs={
-                'sentinel1_product_zip_path': zip_filename,
+                'sentinel1_product_zip_path': product_safe_path,
                 'granules_paths': granules_paths,
                 'granules_upload_dir':self.granules_upload_dir,
+                'working_dir': self.working_dir
             }
         )
-        po.execute(context)
+        zip_paths=list()
+        zip_paths.append(po.execute(context))
+        return zip_paths
 
 class MoveFilesOperator(BaseOperator):
     @apply_defaults

--- a/airflow/plugins/geoserver_plugin.py
+++ b/airflow/plugins/geoserver_plugin.py
@@ -1,7 +1,10 @@
 import logging
+import requests
+from pprint import pprint, pformat
 from airflow.operators import BaseOperator
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.decorators import apply_defaults
+from airflow.models import XCOM_RETURN_KEY
 import config.xcom_keys as xk
 from geoserver.catalog import Catalog
 
@@ -31,6 +34,101 @@ class GSAddMosaicGranule(BaseOperator):
         granule = 'file://' + self.mosaic_path + '/' + granule
         log.info(granule)
         self.catalog.harvest_externalgranule(granule, store)
+
+def generate_wfs_dict(s2_product, GS_WORKSPACE, GS_LAYER):
+    return {
+        "offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wfs",
+        "method": "GET",
+        "code": "GetFeature",
+        "type": "application/json",
+        "href": r"${BASE_URL}"+"/{}/ows?service=wfs&version=2.0.0&request=GetFeature&typeNames={}:{}&CQL_FILTER=eoIdentifier='{}'&outputFormat=application/json".format(
+            GS_WORKSPACE,
+            GS_WORKSPACE,
+            GS_LAYER, 
+            s2_product.manifest_safe_path.rsplit('.SAFE', 1)[0])
+    }
+
+def generate_wms_dict(GS_WORKSPACE, GS_LAYER, granule_coordinates, GS_WMS_WIDTH, GS_WMS_HEIGHT, GS_WMS_FORMAT, s2_product):
+    bbox = str(granule_coordinates[0][3][0])+","+str(granule_coordinates[0][1][0])
+    return {
+        "offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wms",
+        "method": "GET", 
+        "code": "GetMap", 
+        "type": "image/jpeg", 
+        "href": r"${BASE_URL}"+"/{}/{}/ows?service=wms&request=GetMap&version=1.3.0&LAYERS={}&BBOX={}&WIDTH={}&HEIGHT={}&FORMAT=image/jpeg&CQL_FILTER=eoIdentifier='{}'".format(
+            GS_WORKSPACE, 
+            GS_LAYER, 
+            GS_LAYER, 
+            bbox.strip(), 
+            GS_WMS_WIDTH, 
+            GS_WMS_HEIGHT, 
+            s2_product.manifest_safe_path.rsplit('.SAFE', 1)[0])
+    }
+
+def generate_wcs_dict(granule_coordinates, GS_WORKSPACE, s2_product, coverage_id):
+    long1, long2 = (float(granule_coordinates[0][3][0].split(",")[0]),float(granule_coordinates[0][1][0].split(",")[0]))
+    lat1, lat2 = (float(granule_coordinates[0][3][0].split(",")[1]),float(granule_coordinates[0][1][0].split(",")[1]))
+    return {
+        "offering": "http://www.opengis.net/spec/owc-atom/1.0/req/wcs",
+        "method": "GET",
+        "code": "GetCoverage",
+        "type": "image/jp2",
+        "href": r"${BASE_URL}"+"/{}/wcs?service=WCS&version=2.0.1&coverageId={}&request=GetCoverage&format=jpeg2000&subset=http://www.opengis.net/def/axis/OGC/0/Long({},{})&subset=http://www.opengis.net/def/axis/OGC/0/Lat({},{})&scaleaxes=i(0.1),j(0.1)&CQL_FILTER=eoIdentifier='{}'".format(
+            GS_WORKSPACE, 
+            coverage_id, 
+            str(long1).strip(), 
+            str(long2).strip(), 
+            str(lat1).strip(), 
+            str(lat2).strip(), 
+            s2_product.manifest_safe_path.rsplit('.SAFE', 1)[0])
+    }
+
+def publish_product(geoserver_username, geoserver_password, geoserver_rest_endpoint, get_inputs_from, *args, **kwargs):
+    # Pull Zip path from XCom
+    log.info("publish_product task")
+    log.info("""
+        geoserver_username: {}
+        geoserver_password: ******
+        geoserver_rest_endpoint: {}
+        """.format(
+            geoserver_username,
+            geoserver_rest_endpoint
+        )
+    )
+    task_instance = kwargs['ti']
+
+    zip_files=list()
+    if get_inputs_from != None:
+        log.info("Getting inputs from: " +get_inputs_from)
+        zip_files = task_instance.xcom_pull(task_ids=get_inputs_from, key=XCOM_RETURN_KEY)
+    else:
+        log.info("Getting inputs from: product_zip_task" )
+        zip_files = task_instance.xcom_pull('product_zip_task', key='product_zip_paths')
+    
+    log.info("zip_file_paths: {}".format(zip_files))
+    if zip_files is not None:
+        published_ids=list()
+        for zip_file in zip_files:
+            # POST product.zip
+            d = open(zip_file, 'rb').read()
+            a = requests.auth.HTTPBasicAuth(geoserver_username, geoserver_password)
+            h = {'Content-type': 'application/zip'}
+
+            r = requests.post(geoserver_rest_endpoint,
+                auth=a,
+                data=d,
+                headers=h)
+
+            if r.status_code == 201:
+                published_ids.append(r.text)
+                log.info("Successfully published product '{}' (HTTP {})".format(r.text,r.status_code))
+            elif r.status_code == 500:
+                log.warn("Error during publishing product '{}' (HTTP {}: {})".format(zip_file, r.status_code, r.text))
+            else:
+                log.warn("Unknown response during publishing '{}' (HTTP {}: {})".format(zip_file, r.status_code, r.text))
+        return published_ids
+    else:
+        log.warn("No product.zip found.")
 
 class GDALPlugin(AirflowPlugin):
     name = "GeoServer_plugin"

--- a/airflow/plugins/sentinel2_metadata_plugin.py
+++ b/airflow/plugins/sentinel2_metadata_plugin.py
@@ -10,7 +10,7 @@ from pgmagick import Image, Blob
 import 	zipfile, json
 import shutil
 import xml.etree.ElementTree as ET
-from sentinel2.utils import generate_wfs_dict, generate_wcs_dict, generate_wms_dict
+from geoserver_plugin import generate_wfs_dict, generate_wcs_dict, generate_wms_dict
 
 ''' This class will create a compressed, low resolution, square shaped thumbnail for the
 original granule. the current approach is generating a new folder that will contain all the metadata files if it wasn't created. if it was created, then Sentinel2ThumbnailOperator will delete it and create a new empty one and then append the created thumbnail to it. by this way, later operators can append to this directory per product.
@@ -64,7 +64,7 @@ class Sentinel2ThumbnailOperator(BaseOperator):
                     for granule in safe_product.granules:
                         try:
                             zipf = zipfile.ZipFile(product, 'r')
-                            imgdata = zipf.read(granule.tci_path,'r')
+                            imgdata = zipf.read(granule.pvi_path,'r')
                             img = Blob(imgdata)
                             img = Image(img)
                             img.scale(self.thumb_size_x+'x'+self.thumb_size_y)
@@ -132,6 +132,7 @@ class Sentinel2MetadataOperator(BaseOperator):
 
         services= [{"wms":("GetCapabilities","GetMap")},{"wfs":("GetCapabilities","GetFeature")},{"wcs":("GetCapabilities","GetCoverage")}]
         for product in self.downloaded_products.keys():
+            log.info("Processing: {}".format(product))
             with s2reader.open(product) as s2_product:
                 coords = []
                 links=[]


### PR DESCRIPTION
This commits replaces the existing `Sentinel1.py` DAG with a new `S1_GRD_1SDV.py` DAG that follows the naming conventions and concepts detailed in #118. It now uses the 
    
- The DHUS plugin now also check if an product exists before downloading and in that case it tries to download the next until the download limit is reached. Furthermore 
    
 - The `S1MetadataOperator` and `ZipInspector` now allows to use the `get_inputs_from` parameter and returns it's output with `return`

- #192 is fixed by using the granules coordinates also for the product.json
    
 - The `generate_wcs|wfs|wms_dict` and `publish_product` methods have now been moved to the `geoserver_plugin.py` so that it can be reused by other DAGs.
    
Resolves: #190, #192 