### PR TITLE
fix L8 granules.json #219

### DIFF
--- a/airflow/plugins/evo-odas_plugin.py
+++ b/airflow/plugins/evo-odas_plugin.py
@@ -129,6 +129,7 @@ class RSYNCOperator(BaseOperator):
         bash_command = 'rsync -avHPze "ssh -i ' + self.ssh_key_file + ' -o StrictHostKeyChecking=no" ' + files_str + ' ' + self.remote_usr + '@' + self.host + ':' + self.remote_dir
         bo = BashOperator(task_id='bash_operator_rsync_', bash_command=bash_command)
         bo.execute(context)
+        return files_str
 
 class S1MetadataOperator(BaseOperator):
     @apply_defaults


### PR DESCRIPTION
- RSYNCOperator push path to XCom
- Change L8 DAG tasks layout to have "generate_metadata" after granules processing and upload. This allows the task to know the final "location" of the granules
- Improve prepare_granules to support multiple bands and populate granules.json dictionary with band names