### PR TITLE
adding originalpackagelocation property to Sentinel-2 product.json file

### DIFF
--- a/airflow/dags/config/s2_msi_l1c.py
+++ b/airflow/dags/config/s2_msi_l1c.py
@@ -18,6 +18,7 @@ download_dir = os.path.join(collection_dir,"download")
 process_dir = os.path.join(collection_dir,"process")
 upload_dir = os.path.join(collection_dir,"upload")
 repository_dir = os.path.join(collection_dir,"repository")
+original_package_download_base_url = "http://geoserver.cloudsdi.geo-solutions.it/data/sentinel/sentinel2/S2_MSI_L1C"
 
 #
 # DHUS specific

--- a/airflow/dags/sentinel2/S2_MSI_L1C.py
+++ b/airflow/dags/sentinel2/S2_MSI_L1C.py
@@ -115,7 +115,8 @@ metadata_task = Sentinel2MetadataOperator(task_id = 'extract_metadata_task',
                                           GS_WCS_SCALE_I = S2MSIL1C.geoserver_oseo_wcs_scale_i,
                                           GS_WCS_SCALE_J = S2MSIL1C.geoserver_oseo_wcs_scale_j,
                                           GS_WCS_FORMAT = S2MSIL1C.geoserver_oseo_wcs_format,
-                                          get_inputs_from=download_task.task_id,
+                                          get_inputs_from = [download_task.task_id, archive_task.task_id],
+                                          ORIGINAL_PACKAGE_DOWNLOAD_BASE_URL = S2MSIL1C.original_package_download_base_url,
                                           dag = dag)
 
 # Archive Sentinel-2 RSYNC with .prj and .wld files Task Operator


### PR DESCRIPTION
This PR includes adding the originalPackageLocation to the product.json file for Sentinel2 products.
The changes utilized the get_inputs_from configuration mechanism and is allowing to set the URL dynamically according to (original_package_download_base_url and the uploaded product zipfile name).