### PR TITLE
issue 254

### DIFF
--- a/airflow/dags/config/landsat8.py
+++ b/airflow/dags/config/landsat8.py
@@ -36,6 +36,18 @@ Landsat8Area = namedtuple("Landsat8Area", [
     "bands"
 ])
 
+# please change the number of days to increase/decrease the time interval for searching
+startdate = datetime.today() - timedelta(days=100)
+enddate = datetime.now()
+filter_max = 5
+
+ascending = "ASC"
+descending = "DESC"
+
+# please use acquisitiondate or cloudCover to order by 
+order_by = "acquisitiondate"
+# please use ascending or descending for ordering type
+order_type = ascending
 
 AREAS = [
     Landsat8Area(name="daraa", path=174, row=37, bands=range(1, 12)),

--- a/airflow/dags/landsat8/L8_download_process.py
+++ b/airflow/dags/landsat8/L8_download_process.py
@@ -63,6 +63,11 @@ def generate_dag(area, download_dir, default_args):
         task_id='search_{}'.format(area.name),
         area=area,
         cloud_coverage=LANDSAT8.cloud_coverage,
+        startdate = LANDSAT8.startdate,
+        enddate = LANDSAT8.enddate,
+        filter_max =LANDSAT8.filter_max,
+        order_by =LANDSAT8.order_by,
+        order_type =LANDSAT8.order_type,
         db_credentials= CFG.landsat8_postgresql_credentials,
         dag=dag
     )


### PR DESCRIPTION
This PR includes:
- Improving Landsat8 search operator to be more flexible in terms of searching conditions like:

1.    - adding time windows start/end date for searching through the acquisitiondate
2.    - adding filter_max to limit the search results to specific number or scenes/records
3.    - adding the ability to choose which attribute to order by (acquisitiondate or cloudCover)
4.    - adding the ability to choose the type of ordering (ascending or descending)
5.    - the search operator now returns a list of scenes/products instead of single one

Note: point number 4 added since the user might choose to order by cloudCover and hence the user may need the least cloud coverage which is ascending (opposite to acquisitiondate which if searched for latest scene, it will be descending)
Note: table name and sql keywords cannot be parametrized (using %s which is preventing sql injection) so we had to use .format to order by.