### PR TITLE
extending issue 254 

### DIFF
--- a/airflow/plugins/search_download_daraa_plugin.py
+++ b/airflow/plugins/search_download_daraa_plugin.py
@@ -55,74 +55,57 @@ class Landsat8SearchOperator(BaseOperator):
         cursor = connection.cursor()
         data = (self.cloud_coverage, self.area.path, self.area.row, self.startdate, self.enddate)
         query = "SELECT productid, entityid, download_url FROM scene_list "
-        self.condition_counter = 0
+
         self.conditions_list = []
         if self.cloud_coverage or self.area.path or self.area.row or self.startdate or self.enddate:
             where_stmt = " WHERE "
+            query+=where_stmt
 
         if self.cloud_coverage:
-            self.condition_counter+=1
             cloud_condition =  " cloudCover < %s "%(self.cloud_coverage)
             self.conditions_list.append(cloud_condition)
         else:
             cloud_condition = ''
 
         if self.area.path:
-            self.condition_counter+=1
             path_condition =  " path = %s "%(self.area.path)
             self.conditions_list.append(path_condition)
         else:
             path_condition = ''
 
         if self.area.row:
-            self.condition_counter+=1
             row_condition =  " row = %s "%(self.area.row)
             self.conditions_list.append(row_condition)
         else:
             row_condition = ''
 
         if self.startdate and self.enddate:
-            self.condition_counter+=1
             startenddate_condition =  " acquisitiondate BETWEEN '%s' AND '%s' "%(self.startdate,self.enddate)
             self.conditions_list.append(startenddate_condition)
         else:
             startenddate_condition = ''
 
         if self.startdate and not self.enddate:
-            self.condition_counter+=1
             startdate_condition =  " acquisitiondate > '%s' "%(self.startdate)
             self.conditions_list.append(startdate_condition)
         else:
             startdate_condition = ''
 
         if self.enddate and not self.startdate:
-            self.condition_counter+=1
             enddate_condition =  " acquisitiondate < '%s' "%(self.enddate)
             self.conditions_list.append(enddate_condition)
         else:
             enddate_condition = ''
 
         conditions = ''
-        self.condition_counter-=1
-        #adding where stmt in case there was condition(s)
-        if self.condition_counter >0:
-            query +=where_stmt
-        #adding AND operator after every condition
-        while self.condition_counter>0:
-            cond = self.conditions_list.pop()
-            self.condition_counter -=1
-            if self.condition_counter>0:
-                conditions+=cond + " AND "
-            else:
-                #if reached to the last condition, don't add AND 
-                conditions+=cond
-        #adding the accumulated conditions to the statement
-        query +=conditions
+        for condition in self.conditions_list:
+            conditions+= condition + " AND "
+
+        query +=conditions.strip(" AND ")
+
         #kindly note that table name and sql keywords cannot be parametrized (e.g: using %s) so we had to use .format to order by 
         query += " ORDER BY {} {} LIMIT {} ".format(self.order_by, self.order_type, self.filter_max)
-
         cursor.execute(query)
-        #product_id, entity_id, download_url = cursor.fetchone()
         search_results = cursor.fetchall()
         if search_results is None:
             log.error("Could not find any product for the {} area".format(self.area))


### PR DESCRIPTION
**This PR is to continue working on issue 254 in terms of:**

- Allowing the user to set a group of conditions without forcing to pass all of them to Landsat-8 search operator.
- The search operator now constructs the search conditions according to the optionally passed parameters.
- If passed startdate only, it will get all scenes since that date till today (note the filter_max param)
- If passed enddate only, it will get all available scenes till that date (note the filter_max param)
- If passed start and end dates, it will work accordingly to fetch scenes taken between those dates
- And same for cloud_coverage, path and row 
