### PR TITLE
Support EOxServer and use common config for template directory

### DIFF
--- a/airflow/dags/config/settings.py
+++ b/airflow/dags/config/settings.py
@@ -31,6 +31,10 @@ geoserver_rest_url = 'http://localhost:8080/geoserver/rest'
 geoserver_username = 'admin'
 geoserver_password = ''
 
+eoxserver_rest_url = 'http://localhost:8080/eoxserver/product/'
+eoxserver_username = ''
+eoxserver_password = ''
+
 postgresql_dbname = 'oseo'
 postgresql_hostname = 'localhost'
 postgresql_port = '5432'

--- a/airflow/dags/config/settings.py
+++ b/airflow/dags/config/settings.py
@@ -2,11 +2,21 @@ import os
 from datetime import datetime, timedelta
 
 #
+# Airflow root directory
+#
+PROJECT_ROOT = os.path.dirname(
+    os.path.dirname(
+        os.path.dirname(__file__)
+    )
+)
+
+#
 # Paths
 #
 base_dir = os.getenv('BASE_DIR','/var/data/')
 regions_base_dir = os.path.join(base_dir, 'regions')
 repository_base_dir = os.getenv('REPOSITORY_DIR',os.path.join(base_dir, 'repository'))
+templates_base_dir = os.getenv('TEMPLATES_DIR', os.path.join(PROJECT_ROOT,'plugins','templates' ))
 
 #
 # Connections

--- a/airflow/dags/config/settings.py
+++ b/airflow/dags/config/settings.py
@@ -31,7 +31,8 @@ geoserver_rest_url = 'http://localhost:8080/geoserver/rest'
 geoserver_username = 'admin'
 geoserver_password = ''
 
-eoxserver_rest_url = 'http://localhost:8080/eoxserver/product/'
+#eoxserver_rest_url = 'http://localhost:8080/eoxserver/product/'
+eoxserver_rest_url = None
 eoxserver_username = ''
 eoxserver_password = ''
 

--- a/airflow/dags/landsat8/L8_download_process.py
+++ b/airflow/dags/landsat8/L8_download_process.py
@@ -242,6 +242,17 @@ def generate_dag(area, download_dir, default_args):
                                   },
                                   dag=dag)
 
+    if CFG.eoxserver_rest_url:
+      publish_eox_task = PythonOperator(task_id="publish_product_eox_task",
+                                    python_callable=publish_product,
+                                    op_kwargs={
+                                      'geoserver_username': CFG.eoxserver_username,
+                                      'geoserver_password': CFG.eoxserver_password,
+                                      'geoserver_rest_endpoint': CFG.eoxserver_rest_url,
+                                      'get_inputs_from': product_zip_task.task_id,
+                                    },
+                                    dag = dag)
+
     download_thumbnail.set_upstream(search_task)
     download_metadata.set_upstream(search_task)
     for tid in download_tasks:
@@ -257,6 +268,9 @@ def generate_dag(area, download_dir, default_args):
     product_zip_task.set_upstream(generate_thumbnail)
     publish_task.set_upstream(upload_original_package_task)
     publish_task.set_upstream(product_zip_task)
+
+    if CFG.eoxserver_rest_url:
+        publish_eox_task.set_upstream(publish_task)
 
     return dag
 

--- a/airflow/dags/landsat8/L8_download_process.py
+++ b/airflow/dags/landsat8/L8_download_process.py
@@ -21,18 +21,6 @@ from landsat8_plugin import create_original_package
 import config as CFG
 import config.landsat8 as LANDSAT8
 
-
-# These ought to be moved to a more central place where other settings might
-# be stored
-PROJECT_ROOT = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(__file__)
-    )
-)
-
-TEMPLATES_PATH = os.path.join(PROJECT_ROOT, "plugins", "templates")
-
-
 def generate_dag(area, download_dir, default_args):
     """Generate Landsat8 ingestion DAGs.
 
@@ -72,7 +60,7 @@ def generate_dag(area, download_dir, default_args):
     generate_html_description = Landsat8ProductDescriptionOperator(
         task_id='generate_html_description',
         description_template=os.path.join(
-            TEMPLATES_PATH, "product_abstract.html"),
+            CFG.templates_base_dir, "product_abstract.html"),
         download_dir=download_dir,
         dag=dag
     )
@@ -227,7 +215,7 @@ def generate_dag(area, download_dir, default_args):
             "gdalinfo_task_id": gdalinfo_task_id,
             "upload_original_package_task_id": upload_original_package_task.task_id,
         },
-        metadata_xml_path=os.path.join(TEMPLATES_PATH, "metadata.xml"),
+        metadata_xml_path=os.path.join(CFG.templates_base_dir, "metadata.xml"),
         dag=dag
     )
 

--- a/airflow/dags/sentinel1/S1_GRD_1SDV.py
+++ b/airflow/dags/sentinel1/S1_GRD_1SDV.py
@@ -225,6 +225,17 @@ publish_task = PythonOperator(task_id="publish_product_task",
                               },
                               dag = dag)
 
+if CFG.eoxserver_rest_url:
+  publish_eox_task = PythonOperator(task_id="publish_product_eox_task",
+                                python_callable=publish_product,
+                                op_kwargs={
+                                  'geoserver_username': CFG.eoxserver_username,
+                                  'geoserver_password': CFG.eoxserver_password,
+                                  'geoserver_rest_endpoint': CFG.eoxserver_rest_url,
+                                  'get_inputs_from': metadata_task.task_id,
+                                },
+                                dag = dag)
+
 download_task.set_upstream(search_task)
 archive_task.set_upstream(download_task)
 zip_task.set_upstream(download_task)
@@ -235,3 +246,6 @@ for task in upload_tasks:
     metadata_task.set_upstream(task)
 
 publish_task.set_upstream(metadata_task)
+
+if CFG.eoxserver_rest_url:
+  publish_eox_task.set_upstream(metadata_task)

--- a/airflow/dags/sentinel2/S2_MSI_L1C.py
+++ b/airflow/dags/sentinel2/S2_MSI_L1C.py
@@ -154,4 +154,17 @@ publish_task = PythonOperator(task_id="publish_product_task",
                               },
                               dag = dag)
 
-search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_wldprj_task >> product_zip_task >> publish_task
+if CFG.eoxserver_rest_url:
+  publish_eox_task = PythonOperator(task_id="publish_product_eox_task",
+                                python_callable=publish_product,
+                                op_kwargs={
+                                  'geoserver_username': '',
+                                  'geoserver_password': '',
+                                  'geoserver_rest_endpoint': CFG.eoxserver_rest_url,
+                                  'get_inputs_from': product_zip_task.task_id,
+                                },
+                                dag = dag)
+  search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_wldprj_task >> product_zip_task >> publish_task >> publish_eox_task
+  
+else:
+  search_task >> download_task >> archive_task >> thumbnail_task >> metadata_task >> archive_wldprj_task >> product_zip_task >> publish_task

--- a/airflow/dags/sentinel2/S2_MSI_L1C.py
+++ b/airflow/dags/sentinel2/S2_MSI_L1C.py
@@ -133,9 +133,7 @@ archive_wldprj_task = RSYNCOperator(task_id="upload_granules",
                                     dag=dag)
 
 ## Sentinel-2 Product.zip Operator.
-# The following variables are just pointing to placeholders until we implement the real files.
-CWR = os.path.dirname(os.path.realpath(__file__))
-placeholders_list = [os.path.join(CWR,"metadata.xml")]
+placeholders_list = [os.path.join(CFG.templates_base_dir,"metadata.xml")]
 generated_files_list = ['product/product.json','product/granules.json','product/thumbnail.jpeg', 'product/owsLinks.json']
 
 product_zip_task = Sentinel2ProductZipOperator(task_id = 'create_product_zip_task',

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -9,18 +9,16 @@ from airflow.models import XCOM_RETURN_KEY
 
 from jinja2 import Environment, FileSystemLoader, Template
 
+import config as CFG
 log = logging.getLogger(__name__)
-
-TEMPLATE_DIR_NAME='templates'
 
 class TemplatesResolver:
 
     def __init__(self):
         dirname = os.path.dirname(os.path.abspath(__file__))
-        template_dir = os.path.join(dirname, TEMPLATE_DIR_NAME)
         log = logging.getLogger(__name__)
-        log.info(pprint.pformat(template_dir))
-        self.j2_env = Environment(loader=FileSystemLoader(template_dir))
+        log.info(pprint.pformat(CFG.templates_base_dir))
+        self.j2_env = Environment(loader=FileSystemLoader(CFG.templates_base_dir))
 
     def generate_product_abstract(self, product_abstract_metadata_dict):
         return self.j2_env.get_template('product_abstract.html').render(product_abstract_metadata_dict)


### PR DESCRIPTION
This PR 
* adds support for L8/S1/S2 product registration in EOxServer when there is a ``eoxserver_rest_url`` configured
* defines a ``central template_base_dir`` configuration and uses it in L8/S1/S2 workflows